### PR TITLE
Support cross compiling from Linux to Windows using MinGW.

### DIFF
--- a/libnethack/src/files.c
+++ b/libnethack/src/files.c
@@ -5,7 +5,7 @@
 
 #if defined(AIMAKE_BUILDOS_MSWin32)
 # define WIN32_LEAN_AND_MEAN
-# include <Windows.h> /* must be before compilers.h */
+# include <windows.h> /* must be before compilers.h */
 
 # if !defined(S_IRUSR)
 #  define S_IRUSR _S_IREAD

--- a/libnethack/src/mail.c
+++ b/libnethack/src/mail.c
@@ -63,6 +63,7 @@ delivermail(const char *from, const char *message)
 void
 checkformail(void)
 {
+#ifndef AIMAKE_BUILDOS_MSWin32
     char *box, *msg;
     FILE* mb;
     char curline[102];
@@ -116,5 +117,6 @@ checkformail(void)
 		
     fclose(mb);
     unlink(box);
+#endif
     return;
 }

--- a/libnethack_common/include/netconnect.h
+++ b/libnethack_common/include/netconnect.h
@@ -30,9 +30,9 @@
 #  include <sys/select.h>
 #  include <sys/time.h>
 # else
-#  include <Winsock2.h>
-#  include <Ws2def.h>
-#  include <Ws2tcpip.h>
+#  include <winsock2.h>
+#  include <ws2def.h>
+#  include <ws2tcpip.h>
 
 #  define snprintf(buf, len, fmt, ...) \
     _snprintf_s(buf, len, len-1, fmt, __VA_ARGS__)

--- a/libuncursed/src/plugins/sdl.c
+++ b/libuncursed/src/plugins/sdl.c
@@ -30,8 +30,8 @@
 #include "uncursed_sdl.h"
 
 #ifdef AIMAKE_BUILDOS_MSWin32
-# include <Winsock2.h>
-# include <Ws2def.h>
+# include <winsock2.h>
+# include <ws2def.h>
 #else
 # include <sys/select.h>
 #endif


### PR DESCRIPTION
Set Windows header file references to be lowercased, so that case-sensitive OS can properly reference them. MinGW header files are in lowercase.

Disable mail feature on Windows, since it doesn't support file locking.